### PR TITLE
fix: add w-fit to link back

### DIFF
--- a/src/app/(app)/found-item/page.js
+++ b/src/app/(app)/found-item/page.js
@@ -25,7 +25,7 @@ export default function FoundItem() {
 
   return (
     <div className="container max-w-6xl mx-auto pt-8 pb-24 px-4 space-y-6">
-      <Link href="/" className="flex items-center space-x-1">
+      <Link href="/" className="flex items-center space-x-1 w-fit">
         <LeftArrowIcon />
         <h3 className="text-2xl font-semibold ">Back</h3>
       </Link>

--- a/src/app/(app)/lost-item/page.js
+++ b/src/app/(app)/lost-item/page.js
@@ -25,7 +25,7 @@ export default function LostPage() {
 
   return (
     <div className="container max-w-6xl mx-auto pt-8 pb-24 px-4 space-y-6">
-      <Link href="/" className="flex items-center space-x-1">
+      <Link href="/" className="flex items-center space-x-1 w-fit">
         <LeftArrowIcon />
         <h3 className="text-2xl font-semibold ">Back</h3>
       </Link>


### PR DESCRIPTION
bug fix:

- add w-fit in <Link></Link> because the link have max-w-6xl so if the user click empty in max-w-6xl redirect to "/"

![image](https://github.com/user-attachments/assets/80ac6bae-dfc7-4018-8631-234957104938)

to 

![image](https://github.com/user-attachments/assets/39a20d42-c5ce-4b1d-afad-f818f0a47cc1)
